### PR TITLE
Remove ENV variables from SConstruct

### DIFF
--- a/firmware/SConstruct
+++ b/firmware/SConstruct
@@ -83,10 +83,7 @@ common_env = Environment(
     CC = 'avr-gcc',
     variables = mcu_vars,
     CCFLAGS = avr_ccflags,
-    CPPDEFINES = avr_cppdefines,
-    ENV = {'PATH' : os.environ['PATH'],
-        'TERM' : os.environ['TERM'],
-        'HOME' : os.environ['HOME']}
+    CPPDEFINES = avr_cppdefines
 )
 
 test_env = Environment(


### PR DESCRIPTION
The ENV variables used in the SConstruct is not always set which can casue
problems. They are now removed since they was never used.